### PR TITLE
Removed extra span from tag

### DIFF
--- a/src/PlayerTagger.ts
+++ b/src/PlayerTagger.ts
@@ -35,7 +35,7 @@ export default class PlayerTagger extends Plugin {
         var tags = this.getTagsForPlayer(playerName);
         tags.forEach((tag) => {
             const span = document.createElement('span');
-            span.innerHTML = `<span>${tag.trim()}</span>`;
+            span.innerHTML = tag.trim();
             span.style.cssText = this.getTagStyle(tag.trim());
             outerSpan.appendChild(span);
         })


### PR DESCRIPTION
Removes the extra span from the Tag which caused default styles to override users styling in the chat version of tagging.